### PR TITLE
fix: allow-list API Platform metadata classes in cache hardening

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -2,7 +2,29 @@
 
 declare(strict_types=1);
 
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Error;
+use ApiPlatform\Metadata\ErrorResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\NotExposed;
+use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use Illuminate\Support\Str;
+use Symfony\Component\TypeInfo\Type\ArrayShapeType;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\Type\NullableType;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\TypeInfo\Type\UnionType;
+use Symfony\Component\WebLink\Link as WebLinkLink;
 
 return [
 
@@ -93,11 +115,47 @@ return [
     | storage. By default, no PHP classes will be unserialized from your
     | cache to prevent gadget chain attacks if your APP_KEY is leaked.
     |
+    | api-platform/laravel caches resource and property metadata through
+    | Cache::store(config('api-platform.cache')) (see CacheResourceCollectionMetadataFactory,
+    | CachePropertyNameCollectionMetadataFactory and CachePropertyMetadataFactory). unserialize()
+    | rejects every class in the cached object graph that isn't explicitly allow-listed here,
+    | not just the outermost one, so all of the following are required. This list was produced
+    | by serializing the ResourceMetadataCollection/PropertyNameCollection/ApiProperty for every
+    | registered API resource and recording every class that appeared; re-run that check (see
+    | tests/Feature/ApiPlatformMetadataCacheTest.php) if new resources introduce new operation,
+    | parameter, or property types.
+    |
     */
 
     'serializable_classes' => [
         stdClass::class,
         Illuminate\Support\Collection::class,
-        Carbon\CarbonImmutable::class
+        Carbon\CarbonImmutable::class,
+
+        // API Platform resource/property metadata (see comment above).
+        ApiProperty::class,
+        ApiResource::class,
+        Error::class,
+        ErrorResource::class,
+        Get::class,
+        GetCollection::class,
+        Link::class,
+        NotExposed::class,
+        Operations::class,
+        Parameters::class,
+        Post::class,
+        PropertyNameCollection::class,
+        QueryParameter::class,
+        ResourceMetadataCollection::class,
+
+        // Symfony type metadata nested inside ApiProperty/QueryParameter.
+        ArrayShapeType::class,
+        BuiltinType::class,
+        CollectionType::class,
+        GenericType::class,
+        NullableType::class,
+        ObjectType::class,
+        UnionType::class,
+        WebLinkLink::class,
     ],
 ];

--- a/tests/Feature/ApiPlatformMetadataCacheTest.php
+++ b/tests/Feature/ApiPlatformMetadataCacheTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * api-platform/laravel caches resource and property metadata via
+ * Cache::store(config('api-platform.cache'))->rememberForever(), which is the
+ * app's "file" store. Laravel's cache deserialization hardening
+ * (config('cache.serializable_classes')) rejects any class in the cached
+ * object graph that isn't explicitly allow-listed, silently turning it into
+ * __PHP_Incomplete_Class. Reading such a value back throws a TypeError as
+ * soon as api-platform tries to use it (e.g. during `package:discover`),
+ * because the factories declare a concrete return type.
+ *
+ * These tests force a real write-then-read round trip through that cache
+ * store for every resource the app registers, so a new operation, parameter,
+ * or property type that introduces an unlisted class fails here instead of
+ * during composer install in CI.
+ */
+it('round-trips every registered resource\'s metadata through the api-platform cache store', function (): void {
+    $cacheStore = Cache::store(config('api-platform.cache'));
+    $resourceNames = app(ResourceNameCollectionFactoryInterface::class)->create();
+    $resourceMetadataFactory = app(ResourceMetadataCollectionFactoryInterface::class);
+
+    expect(iterator_to_array($resourceNames))->not->toBeEmpty();
+
+    foreach ($resourceNames as $resourceClass) {
+        $cacheStore->forget($resourceClass);
+
+        // First call is a cache miss: computes and writes the serialized value.
+        $resourceMetadataFactory->create($resourceClass);
+
+        // Second call is a cache hit: reads the value back from disk through
+        // unserialize(['allowed_classes' => ...]), the path that breaks when
+        // a class in the graph is missing from the allow-list.
+        $metadata = $resourceMetadataFactory->create($resourceClass);
+
+        expect($metadata)->toBeInstanceOf(ResourceMetadataCollection::class);
+
+        foreach ($metadata as $apiResource) {
+            expect($apiResource)->not->toBeInstanceOf(__PHP_Incomplete_Class::class);
+
+            foreach ($apiResource->getOperations() ?? [] as $operation) {
+                expect($operation)->not->toBeInstanceOf(__PHP_Incomplete_Class::class);
+            }
+        }
+    }
+});
+
+it('round-trips every registered resource\'s property metadata through the api-platform cache store', function (): void {
+    $cacheStore = Cache::store(config('api-platform.cache'));
+    $resourceNames = app(ResourceNameCollectionFactoryInterface::class)->create();
+    $propertyNameFactory = app(PropertyNameCollectionFactoryInterface::class);
+    $propertyMetadataFactory = app(PropertyMetadataFactoryInterface::class);
+
+    foreach ($resourceNames as $resourceClass) {
+        $cacheStore->forget($resourceClass);
+
+        $propertyNameFactory->create($resourceClass);
+        $propertyNames = $propertyNameFactory->create($resourceClass);
+
+        expect($propertyNames)->toBeInstanceOf(PropertyNameCollection::class);
+
+        foreach ($propertyNames as $property) {
+            $key = hash('xxh3', serialize(['resource_class' => $resourceClass, 'property' => $property]));
+            $cacheStore->forget($key);
+
+            $propertyMetadataFactory->create($resourceClass, $property);
+            $propertyMetadata = $propertyMetadataFactory->create($resourceClass, $property);
+
+            expect($propertyMetadata)->not->toBeInstanceOf(__PHP_Incomplete_Class::class);
+        }
+    }
+});


### PR DESCRIPTION
Closes #25

api-platform/laravel caches resource and property metadata through
Cache::store(config('api-platform.cache')), which is the app's "file"
cache store and therefore subject to config('cache.serializable_classes').
Since none of the ResourceMetadataCollection/ApiProperty object graph was
allow-listed, unserialize() silently downgraded every nested object to
__PHP_Incomplete_Class, and the factories' typed return declarations then
threw a TypeError as soon as the cache was read back (e.g. during
package:discover).

Add exactly the classes that appear in that object graph today (found by
serializing the real metadata for every registered resource), documented
in config/cache.php so future resources know to re-check the list, and add
a regression test that forces a write-then-read round trip through the
same cache store for every registered resource.