### PR TITLE
docs: sync API package Boost docs with API Platform migration

### DIFF
--- a/packages/vendra-affiliate-api/resources/boost/guidelines/core.blade.php
+++ b/packages/vendra-affiliate-api/resources/boost/guidelines/core.blade.php
@@ -19,5 +19,5 @@ The `misaf/vendra-affiliate-api` package exposes the public referral lookup surf
 - Keep the active-affiliate constraint in the State provider query so collection, filtered, and individual-resource operations enforce the same visibility rule.
 - Keep the `#[ApiResource]` DTOs, State providers/processors, query-parameter and `FormRequest` validation, and operation routes synchronized when the API Platform shape changes.
 - Inherit tenant isolation from the Affiliate model and keep production API code free of `Misaf\VendraTenant` and API tenant toggles. Feature tests may use a concrete tenant factory solely to establish tenant context.
-- Cover public field visibility, active/suspended behavior, filters, routes, and server registration with focused Pest tests.
+- Cover public field visibility, active/suspended behavior, filters, and resource operations with focused Pest tests.
 - Keep `tests/ArchTest.php` enforcing the PHP, security, and Laravel presets plus `not->toUse('Misaf\VendraTenant')`.

--- a/packages/vendra-affiliate-api/resources/boost/skills/vendra-affiliate-api-development/SKILL.md
+++ b/packages/vendra-affiliate-api/resources/boost/skills/vendra-affiliate-api-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vendra-affiliate-api-development
-description: "Create, modify, review, or test the Vendra Affiliate API package in packages/vendra-affiliate-api. Use for the public affiliates API Platform server, AffiliateSchema, AffiliateResource, collection/resource queries, active-affiliate visibility, filters, routes, response fields, API tests, and AffiliateApiServiceProvider wiring."
+description: "Create, modify, review, or test the Vendra Affiliate API package in packages/vendra-affiliate-api. Use for the public affiliate API Platform resources (ReferralCode, ReferralVisit `ApiResource` DTOs), State providers/processors, query parameters, active-affiliate visibility, filters, operations, response fields, API tests, and AffiliateApiServiceProvider wiring."
 ---
 
 # Vendra Affiliate API

--- a/packages/vendra-api/resources/boost/guidelines/core.blade.php
+++ b/packages/vendra-api/resources/boost/guidelines/core.blade.php
@@ -1,6 +1,6 @@
 ## Vendra API
 
-The `misaf/vendra-api` package provides shared API Platform for Laravel infrastructure — reusable filters, sorters, and server wiring — consumed by the per-domain API modules (`misaf/vendra-*-api`).
+The `misaf/vendra-api` package provides shared API Platform for Laravel infrastructure — reusable `ApiResource` DTOs such as `ResourceReference`, the generic `EloquentResourceProvider` state provider, and service-provider wiring — consumed by the per-domain API modules (`misaf/vendra-*-api`).
 
 ### Translatable Persistence
 
@@ -15,10 +15,10 @@ The `misaf/vendra-api` package provides shared API Platform for Laravel infrastr
 - Apply this only to Vendra platform packages listed under `require`; never extend it to `require-dev`, `suggest`, incidental implementation dependencies, or third-party packages. Removing or replacing an exposed dependency is a breaking change; keep `self.version` alignment across the Vendra package graph.
 
 - Keep shared API code inside `packages/vendra-api` using the `Misaf\VendraApi` namespace.
-- Use this package for cross-cutting API Platform building blocks: reusable `JsonApi/Filters`, `JsonApi/Sorting`, and API service-provider wiring. Domain schemas, resources, and routes belong in the per-domain API modules, not here.
+- Use this package for cross-cutting API Platform building blocks: shared `ApiResource` DTOs such as `ResourceReference`, the generic `EloquentResourceProvider` state provider, and API service-provider wiring. Domain resources, state providers, and routes belong in the per-domain API modules, not here.
 - Keep every domain API localization-package agnostic: do not require `misaf/vendra-localization` or attach `vendra.locale` inside API packages. Locale-aware behavior may read Laravel's current locale, while the host application decides whether and how to resolve it.
 - Depend only on framework and API Platform packages. Never import a domain module or a concrete tenant provider such as `Misaf\VendraTenant`; this module stays domain- and tenant-agnostic.
-- Keep filters and sorters generic and reusable across resource types, and keep their behavior covered by focused tests.
+- Keep shared DTOs and the generic state provider reusable across resource types, and keep their behavior covered by focused tests.
 - Follow Laravel comment style: document with PHPDoc (array shapes, generics, `@see`) and reserve inline comments for genuinely complex logic. Match the surrounding file and do not add comments that restate the code.
 - Keep tests purposeful and prevent unnecessary ones: cover behavior, contracts, and edge cases — not framework internals or trivially typed code.
 - Keep Pest architecture tests in `tests/ArchTest.php`: the `php`, `security`, and `laravel` presets plus `arch()->expect('Misaf\VendraApi')->not->toUse('Misaf\VendraTenant')`.

--- a/packages/vendra-api/resources/boost/skills/vendra-api-development/SKILL.md
+++ b/packages/vendra-api/resources/boost/skills/vendra-api-development/SKILL.md
@@ -31,14 +31,14 @@ description: "Create, modify, review, or test the Vendra API infrastructure modu
 Treat `packages/vendra-api` as shared API Platform infrastructure, not a domain API.
 
 - Use namespace `Misaf\VendraApi`.
-- Keep only cross-cutting, reusable API Platform building blocks here: `JsonApi/Filters`, `JsonApi/Sorting`, and API service-provider wiring.
-- Do not add domain schemas, resources, routes, or servers here — those live in the per-domain API modules (`vendra-faq-api`, `vendra-product-api`, `vendra-multimedia-api`, `vendra-blog-api`, `vendra-custom-page-api`).
+- Keep only cross-cutting, reusable API Platform building blocks here: shared `ApiResource` DTOs such as `ResourceReference`, the generic `EloquentResourceProvider` state provider in `State`, and API service-provider wiring.
+- Do not add domain resources, state providers, or routes here — those live in the per-domain API modules (`vendra-faq-api`, `vendra-product-api`, `vendra-multimedia-api`, `vendra-blog-api`, `vendra-custom-page-api`, `vendra-cart-api`).
 - Keep all API packages localization-package agnostic: do not require `misaf/vendra-localization` or attach `vendra.locale`; the host application owns optional locale resolution.
 - Never depend on a domain module or a concrete tenant provider (`Misaf\VendraTenant`); this package must build and run standalone and tenant-agnostic.
 
 ## Standards
 
-- Keep filters and sorters generic and resource-type agnostic so any domain API can reuse them.
+- Keep shared DTOs and the generic state provider resource-type agnostic so any domain API can reuse them.
 - Follow Laravel comment style: PHPDoc with array shapes and generics; inline comments only for genuinely complex logic.
 - Keep public class and method signatures stable — these are consumed by every domain API module.
 

--- a/packages/vendra-attribute-api/resources/boost/guidelines/core.blade.php
+++ b/packages/vendra-attribute-api/resources/boost/guidelines/core.blade.php
@@ -15,10 +15,10 @@ The `misaf/vendra-attribute-api` package exposes active attributes and their val
 - Apply this only to Vendra platform packages listed under `require`; never extend it to `require-dev`, `suggest`, incidental implementation dependencies, or third-party packages. Removing or replacing an exposed dependency is a breaking change; keep `self.version` alignment across the Vendra package graph.
 
 - Keep API code inside `packages/vendra-attribute-api` using the `Misaf\VendraAttributeApi` namespace; keep models and persistence in `misaf/vendra-attribute`.
-- Register both `AttributeSchema` and `AttributeValueSchema` on the v1 server. Keep the `attributes` and `attribute-values` routes read-only and synchronize schemas, resources, queries, routes, and tests when either contract changes.
+- Expose both the `CatalogAttribute` (`Attribute`) and `CatalogOption` (`AttributeValue`) `ApiResource` DTOs. Keep the operations read-only and synchronize the DTOs, state providers, query parameters, and tests when either contract changes.
 - Preserve the attribute shape (`name`, `description`, `unit`, `position`, `active`) and the attribute-value shape (`attribute_id`, `value`, read-only `position`). List/show only active attributes and values belonging to active attributes; do not expose polymorphic type/ID internals.
-- Bind `AttributeApiResolver` to this package's provider-neutral resolver so product APIs can obtain the attribute-value schema without importing this package. Product categories expose `attributeValues`; products expose `attributeValues` and `selectedAttributeValues`.
-- Keep endpoints read-only while `Server::authorizable()` is false; do not add mutations without an authorization design and tests.
-- Keep both resource families' schemas, resources, query validators, server registration, routes, filters, and tests synchronized; request validation rules must match the schemas' filters and pagination.
+- Bind `AttributeApiResolver` to this package's provider-neutral resolver so product APIs can obtain the attribute-value resource without importing this package. Product categories expose `attributeValues`; products expose `attributeValues` and `selectedAttributeValues`.
+- Keep endpoints read-only and non-authorizable; do not add mutations without an authorization design and tests.
+- Keep both resource families' DTOs, state providers, query parameters, service-provider registration, filters, and tests synchronized.
 - Inherit tenant isolation from `AttributeValue` and keep production API code free of `Misaf\VendraTenant` and API tenant toggles. Feature tests may use a concrete tenant factory solely to establish tenant context.
 - Keep `tests/ArchTest.php` enforcing the PHP, security, and Laravel presets plus `not->toUse('Misaf\VendraTenant')`.

--- a/packages/vendra-attribute-api/resources/boost/skills/vendra-attribute-api-development/SKILL.md
+++ b/packages/vendra-attribute-api/resources/boost/skills/vendra-attribute-api-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vendra-attribute-api-development
-description: "Create, modify, review, or test the Vendra Attribute API package in packages/vendra-attribute-api. Use for the v1 API Platform server, AttributeSchema / AttributeResource, AttributeValueSchema / AttributeValueResource, active-resource filtering, provider-neutral product API relationships, filters, routes, response fields, read-only behavior, API tests, and AttributeApiServiceProvider wiring."
+description: "Create, modify, review, or test the Vendra Attribute API package in packages/vendra-attribute-api. Use for the Attribute and AttributeValue API Platform resources (`ApiResource` DTOs), State providers, active-resource filtering, provider-neutral product API relationships, query parameters, operations, response fields, read-only behavior, API tests, and AttributeApiServiceProvider wiring."
 ---
 
 # Vendra Attribute API
@@ -32,14 +32,14 @@ Use `vendra-api-development` for shared API Platform infrastructure, `laravel-be
 
 - Work inside `packages/vendra-attribute-api` with namespace `Misaf\VendraAttributeApi`.
 - Reuse `Misaf\VendraAttribute\Models\Attribute` and `AttributeValue`; do not duplicate attribute persistence or polymorphic relationships.
-- Register both `AttributeSchema` and `AttributeValueSchema`. Preserve the attribute shape (`name`, `description`, `unit`, `position`, `active`) and attribute-value shape (`attribute_id`, `value`, read-only `position`). List/show only active attributes and values belonging to active attributes. Keep raw `attributable_type` and `attributable_id` private.
-- Keep the API read-only while the server is non-authorizable; do not add generic mutations.
+- Expose both the `CatalogAttribute` (`Attribute`) and `CatalogOption` (`AttributeValue`) `ApiResource` DTOs. Preserve the attribute shape (`name`, `description`, `unit`, `position`, `active`) and attribute-value shape (`attribute_id`, `value`, read-only `position`). List/show only active attributes and values belonging to active attributes. Keep raw `attributable_type` and `attributable_id` private.
+- Keep the API read-only and non-authorizable; do not add generic mutations.
 - Bind the Support `AttributeApiResolver` to `AttributeApiServiceResolver`. Product API integration must consume that provider-neutral contract: product categories expose `attributeValues`, while products expose `attributeValues` and `selectedAttributeValues`; neither API package imports the other.
 - Inherit tenant scoping from the domain model and keep the production `Misaf\VendraAttributeApi` namespace free of `Misaf\VendraTenant`. Feature tests may use a concrete tenant factory solely to establish tenant context.
 
 ## Change Checklist
 
-- Update both schemas, resources, query validators, server registration, routes, and tests together.
-- Add focused Pest coverage for both resource types, active-resource filtering, fields, filters, pagination, read-only behavior, and server schema registration.
+- Update both `ApiResource` DTOs, State providers, query parameters, service-provider registration, and tests together.
+- Add focused Pest coverage for both resource types, active-resource filtering, fields, filters, pagination, read-only behavior, and resource registration.
 - Preserve the architecture expectation that `Misaf\VendraAttributeApi` does not use `Misaf\VendraTenant`.
 - Run `composer --working-dir=packages/vendra-attribute-api test` and `composer --working-dir=packages/vendra-attribute-api analyse`; run Pint when PHP changes.

--- a/packages/vendra-blog-api/resources/boost/guidelines/core.blade.php
+++ b/packages/vendra-blog-api/resources/boost/guidelines/core.blade.php
@@ -15,13 +15,13 @@ The `misaf/vendra-blog-api` package exposes `misaf/vendra-blog` domain models th
 - Apply this only to Vendra platform packages listed under `require`; never extend it to `require-dev`, `suggest`, incidental implementation dependencies, or third-party packages. Removing or replacing an exposed dependency is a breaking change; keep `self.version` alignment across the Vendra package graph.
 
 - Keep API code inside `packages/vendra-blog-api` using the `Misaf\VendraBlogApi` namespace.
-- Use this package for API Platform servers, schemas, resources, query validators, API routes, service providers, and API tests.
+- Use this package for API Platform resources (`ApiResource` DTOs), state providers, query parameters, service providers, and API tests.
 - Import domain models from `Misaf\VendraBlog`; do not duplicate persistence or domain behavior in the API module.
 - Keep Filament/admin UI in `misaf/vendra-blog`.
 - Respect domain model tenancy. Tenant awareness is owned by `misaf/vendra-support` and derives from the bound `TenantResolver` (installing `misaf/vendra-tenant` enables it); there is no `tenant_aware` config toggle.
-- Keep production API code tenant-provider agnostic: inherit tenancy through the `Misaf\VendraBlog` models and never reference `Misaf\VendraTenant` in servers, schemas, queries, or routes. Feature tests may use a concrete tenant factory solely to establish tenant context; architecture expectations remain scoped to the production `Misaf\VendraBlogApi` namespace.
-- Keep schema filters and request validation rules synchronized.
+- Keep production API code tenant-provider agnostic: inherit tenancy through the `Misaf\VendraBlog` models and never reference `Misaf\VendraTenant` in resources, state providers, or query parameters. Feature tests may use a concrete tenant factory solely to establish tenant context; architecture expectations remain scoped to the production `Misaf\VendraBlogApi` namespace.
+- Declare query parameters on the resource operations and apply them in the state provider.
 - Follow Laravel comment style: document with PHPDoc (array shapes, generics, `@see`) and reserve inline comments for genuinely complex logic. Match the surrounding file and do not add comments that restate the code.
-- Add or update Pest tests for routes, server schema registration, filters, includes, pagination, sorting, sparse fieldsets, and relationship endpoints.
+- Add or update Pest tests for each resource operation, query parameters, and pagination.
 - Keep tests purposeful and prevent unnecessary ones: cover behavior, contracts, and edge cases — not framework internals or trivially typed code. Do not duplicate coverage a focused test already proves, and do not add throwaway verification scripts when a test fits.
 - Keep Pest architecture tests in `tests/ArchTest.php`: the `php`, `security`, and `laravel` presets plus a tenant-agnostic expectation, e.g. `arch()->expect('Misaf\VendraBlogApi')->not->toUse('Misaf\VendraTenant')`.

--- a/packages/vendra-blog-api/resources/boost/skills/vendra-blog-api-development/SKILL.md
+++ b/packages/vendra-blog-api/resources/boost/skills/vendra-blog-api-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vendra-blog-api-development
-description: "Create, modify, review, or test the Vendra Blog API module in packages/vendra-blog-api. Use for ApiResource DTOs, schemas, resources, collection queries, resource queries, API Platform routes, include paths, filters, pagination, sortables, multimedia API relationships, API tests, and package service provider wiring."
+description: "Create, modify, review, or test the Vendra Blog API module in packages/vendra-blog-api. Use for ApiResource DTOs, State providers, query parameters, API Platform operations, filters, pagination, category and multimedia relationships, API tests, and package service provider wiring."
 ---
 
 # Vendra Blog API
@@ -31,65 +31,57 @@ description: "Create, modify, review, or test the Vendra Blog API module in pack
 Treat `packages/vendra-blog-api` as the API Platform layer for `vendra-blog`.
 
 - Use namespace `Misaf\VendraBlogApi`.
-- Keep API servers, schemas, API resources, query validators, routes, service providers, and API tests inside this module.
+- Keep API resource DTOs, state providers, query parameters, service providers, and API tests inside this module.
 - Import domain models from `Misaf\VendraBlog`; do not duplicate domain models or persistence logic in the API module.
-- Keep production API code tenant-provider agnostic: inherit tenancy from the domain models and add no API tenant toggle or `Misaf\VendraTenant` reference in servers, schemas, queries, or routes. Feature tests may use a concrete tenant factory solely to establish tenant context; keep the architecture rule scoped to `Misaf\VendraBlogApi`.
+- Keep production API code tenant-provider agnostic: inherit tenancy from the domain models and add no API tenant toggle or `Misaf\VendraTenant` reference in resources, state providers, or query parameters. Feature tests may use a concrete tenant factory solely to establish tenant context; keep the architecture rule scoped to `Misaf\VendraBlogApi`.
 - Keep Filament/admin UI out of this module.
 - Keep dependencies explicit in `composer.json`; do not add or change package dependencies without approval.
 - Follow Laravel comment style: document with PHPDoc (array shapes, generics, `@see`) and reserve inline comments for genuinely complex logic. Match the surrounding file's density and do not add comments that restate the code.
 
 ## API Platform Shape
 
-Follow the current `JsonApi/V1` layout.
+Expose read models as API Platform resources in `src/ApiResource` (`Article`, `ArticleSection`), backed by state providers in `src/State` (for example `BlogResourceProvider`).
 
-- Register routes in `routes/api.php` with `JsonApiRoute::server('vendra-blog')->prefix('v1')`.
-- Use `JsonApiController` for standard resource endpoints.
-- Keep resource type names kebab-case and stable, for example `blog-posts` and `blog-post-categories`.
-- Register schemas in `API Platform resource discovery`.
-- Keep `authorizable()` behavior intentional; do not silently enable or disable authorization.
-- Use schema classes for fields, relationships, filters, pagination, and sortables.
+- Define each resource as a `final readonly` DTO annotated with `#[ApiResource]`, declaring `Get`/`GetCollection` operations with explicit `uriTemplate` paths and a `provider`.
+- Keep each resource `shortName` and URI path stable and kebab-case, for example `/content/blog-posts`, `/content/blog-post-categories`.
+- Reference related resources, including categories and multimedia, with `Misaf\VendraApi\ApiResource\ResourceReference` instead of embedding foreign models.
+- Register the `src/ApiResource` directory into `api-platform.resources` and tag each state provider as `ProviderInterface` in the module service provider.
+- Keep resources read-only unless a mutation is an explicit product decision.
 
-## Schema Standards
+## Resource DTO Standards
 
-Schema classes define the public API contract.
+Resource DTOs define the public API contract.
 
-- Use `ID::make()` and typed field classes instead of raw arrays.
-- Use `ArrayHash` for translated JSON columns such as `name`, `description`, and `slug`.
-- Mark generated, positional, timestamp, media, and relationship fields read-only where clients should not mutate them.
-- Keep include paths explicit and minimal.
-- Use `PagePagination::make()` and preserve default pagination unless product requirements change.
-- Expose sortable fields with `->sortable()` and add custom sortables, such as `RandomPositionSort`, in `sortables()`.
-- Keep relationship names aligned with the domain model methods: `blogPostCategory`, `blogPosts`, and `multimedia`.
+- Mark the identifier property with `#[ApiProperty(identifier: true)]` and give every property an explicit type.
+- Expose translated columns as `array<string, string>` locale maps such as `title` and `description`.
+- Keep raw foreign keys and internal columns off the DTO; expose only intentionally public fields.
+- Do the Eloquent querying, hydration, filtering, and pagination in the state provider, not the DTO.
 
 ## Filter And Query Standards
 
-Keep schema filters and request validation in sync.
+Declare supported query parameters on the resource operation.
 
-- Add every schema filter to the matching `ResourceQuery` or `CollectionQuery` validation rules.
-- Declare supported query parameters with API Platform filters and Laravel validation constraints.
-- For translated attribute filters, use the active locale path such as `name->{$locale}` and `slug->{$locale}`.
-- Use `like` filters with deserialization only for intentional partial text search.
-- Use `WhereIdIn` and `WhereIdNotIn` for id inclusion and exclusion.
-- Use `Has`, `WhereHas`, and `WhereDoesntHave` for relationship filters.
-- Keep soft-delete filter rules aligned with actual schema behavior before exposing `with-trashed` or `only-trashed`.
+- Add each filter as a `QueryParameter` with an API Platform filter (`EqualsFilter`, `BooleanFilter`, ...) and Laravel `constraints`.
+- Set each parameter's `property` to the model column the state provider filters on.
+- Apply the declared parameters inside the state provider when building the Eloquent query.
+- For translated column filters, filter on the active-locale JSON path.
 
 ## Service Provider And Routes
 
 Keep package bootstrapping minimal and predictable.
 
-- Use `BlogApiServiceProvider` for package configuration and route loading.
-- Load only this module's API routes from the API module.
-- Keep routes localization-package agnostic and use only Laravel's `api` middleware. Locale-aware filters read Laravel's current locale, which the host application may resolve by any mechanism.
-- Do not use host-app route files for module endpoints unless integrating the package at application level.
+- Use `BlogApiServiceProvider` to register `src/ApiResource` into `api-platform.resources` and tag the state providers; API Platform generates routes from the resource operations.
+- Do not hand-register route files for resource endpoints.
+- Keep routes localization-package agnostic; locale-aware providers read Laravel's current locale, which the host application may resolve by any mechanism.
 
 ## Testing And Verification
 
 Use Pest tests to protect API contracts.
 
 - Keep tests purposeful and prevent unnecessary ones: cover behavior, contracts, and edge cases — not framework internals or trivially typed code. Do not duplicate coverage a focused test already proves, and do not add throwaway verification scripts (or `tinker`) when a test fits.
-- Add route tests for every new resource endpoint and relationship endpoint.
-- Add server tests when schemas, resource names, or `Server` behavior changes.
-- Add request validation tests when filters, includes, sparse fieldsets, sorting, pagination, or relationship filters change.
+- Add tests for every new resource operation and its query parameters.
+- Add tests when resource shape, `shortName`, or URI paths change.
+- Add tests when query parameters, filters, or pagination change.
 - Keep Pest architecture tests in `tests/ArchTest.php`: the `php`, `security`, and `laravel` presets, plus an expectation that the module stays tenant-agnostic, e.g. `arch()->expect('Misaf\VendraBlogApi')->not->toUse('Misaf\VendraTenant')`. The API module may depend on `Misaf\VendraBlog`, but not on any concrete tenant provider.
 - Run module checks from the package when possible: `composer --working-dir=packages/vendra-blog-api test` and `composer --working-dir=packages/vendra-blog-api analyse`.
 - If PHP files changed, run Pint for the touched code: `vendor/bin/pint --dirty --format agent` from the host app, or the module formatter if working only inside the package.

--- a/packages/vendra-cart-api/resources/boost/guidelines/core.blade.php
+++ b/packages/vendra-cart-api/resources/boost/guidelines/core.blade.php
@@ -1,6 +1,6 @@
 ## Vendra Cart API
 
-The `misaf/vendra-cart-api` package owns API Platform schemas, resources, query validation, routes, and server wiring for `misaf/vendra-cart`.
+The `misaf/vendra-cart-api` package owns API Platform resources (`ApiResource` DTOs), state providers, query parameters, and service-provider wiring for `misaf/vendra-cart`.
 
 ### Translatable Persistence
 
@@ -16,11 +16,10 @@ The `misaf/vendra-cart-api` package owns API Platform schemas, resources, query 
 
 - Keep cart API code inside `packages/vendra-cart-api` using the `Misaf\VendraCartApi` namespace.
 - Keep cart models, migrations, factories, policies, seeders, and Filament UI in `misaf/vendra-cart`; this package only serializes and routes them.
-- Register `carts` and `cart-items` on the `vendra-cart` API Platform server under `/api`.
-- Keep endpoints read-only until authenticated cart ownership, token access, and mutation authorization are explicitly designed and tested. Never expose unauthenticated cart mutation through the generic API Platform controller.
-- Serialize the cart's human-readable `owner_label`; do not expose raw `owner_type` or `owner_id` attributes.
-- Serialize `sellable_type` and `sellable_id` as identity attributes until every supported sellable type has a registered API Platform schema. Do not claim a polymorphic API Platform relationship with incomplete inverse types.
-- Keep cart/item relationships read-only and support includes for `items` and `cart`.
-- Use focused collection filters for IDs, cart token, expiration, quantity, sellable identity, and relationship presence.
+- Expose the `ShoppingCart` and `CartLine` resources under `/sales/carts`, backed by `ShoppingCartProvider`.
+- Keep the operations read-only and authenticated: attach `middleware: 'auth:sanctum'` and a `policy` enforced by `ShoppingCartPolicy`. Never expose unauthenticated cart mutation.
+- Keep the cart owner morph columns private (`ownerType`, `ownerId`); do not serialize raw `owner_type` or `owner_id`.
+- Serialize each line's `sellableType`, `sellableId`, quantity, and metadata via `CartLine`.
+- Do the Eloquent querying, hydration, and pagination in the state provider, not the DTO.
 - Rely on the cart models' support-layer tenant scope and keep production API code free of `Misaf\VendraTenant`. Feature tests may use a concrete tenant factory solely to establish tenant context.
-- Keep Pest architecture tests and focused route/server/resource tests current.
+- Keep Pest architecture tests and focused resource/state-provider/policy tests current.

--- a/packages/vendra-cart-api/resources/boost/skills/vendra-cart-api-development/SKILL.md
+++ b/packages/vendra-cart-api/resources/boost/skills/vendra-cart-api-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vendra-cart-api-development
-description: "Create, modify, review, or test the Vendra Cart API Platform package in packages/vendra-cart-api. Use for cart or cart-item API Platform schemas, resources, collection/query validation, filters, includes, routes, the vendra-cart API Platform server, CartApiServiceProvider, cart API serialization, or decisions about exposing polymorphic owners and sellables through API Platform."
+description: "Create, modify, review, or test the Vendra Cart API Platform package in packages/vendra-cart-api. Use for the ShoppingCart and CartLine API Platform resources (`ApiResource` DTOs), ShoppingCartProvider state provider, query parameters, operations, authentication and ShoppingCartPolicy, CartApiServiceProvider, cart API serialization, or decisions about exposing polymorphic owners and sellables through API Platform."
 ---
 
 # Vendra Cart API
@@ -35,25 +35,23 @@ Use this skill with `vendra-api-development`, `laravel-best-practices`, and `pes
 - Keep domain behavior, migrations, factories, policies, seeders, and Filament classes out of this package.
 - Keep production API code free of `Misaf\VendraTenant`; model scopes provide tenant isolation. Feature tests may use a concrete tenant factory solely to establish tenant context.
 
-## Server And Routes
+## Resources And Routes
 
-- Register `Server` as `jsonapi.servers.vendra-cart` with base URI `/api`.
-- Expose `carts` and `cart-items` through the package `routes/api.php` using Laravel's `api` middleware without requiring a localization package.
-- Keep generic controller routes read-only until authenticated ownership/token access and mutation authorization have an explicit design.
-- Register read-only `items` and `cart` relationship endpoints.
+- Expose read models as API Platform resources in `src/ApiResource` (`ShoppingCart`, `CartLine`), backed by `ShoppingCartProvider` in `src/State`; API Platform generates routes from the resource operations.
+- Keep the `/sales/carts` operations authenticated: attach `middleware: 'auth:sanctum'` and a `policy` enforced by `ShoppingCartPolicy`.
+- Register the `src/ApiResource` directory into `api-platform.resources` and tag the state provider as `ProviderInterface`; do not hand-register route files.
+- Keep the operations read-only until authenticated ownership/token access and mutation authorization have an explicit design.
 
-## Schemas And Resources
+## Resource DTO Standards
 
-- Serialize cart token, owner label, expiration, timestamps, and items relationship.
-- Never serialize raw cart owner morph columns; use `owner_label`.
-- Serialize item sellable type/ID, quantity, metadata, timestamps, and cart relationship.
-- Keep sellable identity as attributes until all supported sellable resource schemas can be listed on a API Platform for Laravel `MorphTo` field.
-- Mark current fields and relationships read-only to match route behavior.
-- Support pagination, includes, sparse fieldsets, sorts, counts, and focused validated filters consistently with sibling API modules.
+- Serialize cart token, expiration, and the lines relationship; keep the owner morph columns private (`ownerType`, `ownerId`) rather than exposing them.
+- Serialize each line's sellable type/ID, quantity, and metadata via `CartLine`.
+- Reference related resources with `Misaf\VendraApi\ApiResource\ResourceReference` where a full DTO is not exposed.
+- Do the Eloquent querying, hydration, and pagination in the state provider, not the DTO.
 
 ## Verification
 
-- Test route registration, server base URI/schema registration, resource attribute boundaries, and architecture constraints.
+- Test each resource operation, its policy/authentication, resource attribute boundaries, and architecture constraints.
 - Run `php artisan test --compact packages/vendra-cart-api/tests`.
 - Run PHPStan against `packages/vendra-cart-api/src`.
 - Run `vendor/bin/pint --dirty --format agent` after PHP changes.

--- a/packages/vendra-custom-page-api/resources/boost/guidelines/core.blade.php
+++ b/packages/vendra-custom-page-api/resources/boost/guidelines/core.blade.php
@@ -18,10 +18,9 @@ The `misaf/vendra-custom-page-api` package exposes `misaf/vendra-custom-page` do
 - Import `CustomPage` and `CustomPageCategory` from `Misaf\VendraCustomPage`; do not duplicate persistence or domain behavior.
 - Keep the API read-only and tenant-provider agnostic. Tenant scoping comes from the domain models through Vendra Support.
 - Keep the API localization-package agnostic. Use Laravel's `api` middleware only; locale-aware filters read Laravel's current locale without requiring a resolver package.
-- Expose translated `name`, `description`, and `slug` fields as JSON hashes using `getTranslations()` and keep locale-aware filters aligned with request validation.
-- Validate query-string booleans with `JsonApiRule::boolean()->asString()` so validation matches boolean filter deserialization.
-- Register `with-trashed` and `only-trashed` in both collection validation and schema filters.
-- Map the domain models' `MorphMany` multimedia relations with API Platform `HasMany` fields.
-- Keep category, page, and multimedia relationships read-only, with explicit include paths and relationship routes.
-- Add Pest coverage for routes, server schemas, filters, includes, pagination, sorting, relationship endpoints, and tenant isolation.
+- Expose translated `name`, `description`, and `slug` fields as `array<string, string>` locale maps hydrated from the domain models' translations in the state provider.
+- Declare query parameters as `QueryParameter`s on the resource operations, using API Platform filters (`EqualsFilter`, `BooleanFilter`, ...) with Laravel `constraints`, and apply them in the state provider.
+- Reference the domain models' multimedia and category relations with `Misaf\VendraApi\ApiResource\ResourceReference` instead of embedding foreign models.
+- Keep category, page, and multimedia references read-only.
+- Add Pest coverage for each resource operation, query parameters, pagination, and tenant isolation.
 - Keep architecture tests preventing production code from referencing `Misaf\VendraTenant`.

--- a/packages/vendra-custom-page-api/resources/boost/skills/vendra-custom-page-api-development/SKILL.md
+++ b/packages/vendra-custom-page-api/resources/boost/skills/vendra-custom-page-api-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vendra-custom-page-api-development
-description: "Create, modify, review, or test the Vendra Custom Page API Platform package in packages/vendra-custom-page-api, including custom page and category schemas, resources, query validation, relationships, routes, and provider wiring."
+description: "Create, modify, review, or test the Vendra Custom Page API Platform package in packages/vendra-custom-page-api, including the ContentPage and ContentSection `ApiResource` DTOs, ContentResourceProvider state provider, query parameters, relationships, operations, and provider wiring."
 ---
 
 # Vendra Custom Page API
@@ -37,16 +37,14 @@ Use this skill together with `laravel-best-practices` and `pest-testing`.
 
 ## API Platform Contract
 
-- Register the `vendra-custom-page` server at `/api`.
-- Keep `custom-page-categories` and `custom-pages` read-only.
-- Expose translated JSON columns with `ArrayHash` and serialize them with `getTranslations()`.
-- Validate query-string booleans with `JsonApiRule::boolean()->asString()`.
-- Keep `with-trashed` and `only-trashed` synchronized between collection queries and schemas.
-- Represent the domain models' `MorphMany` multimedia relations with API Platform `HasMany`.
-- Keep `customPages`, `customPageCategory`, and `multimedia` relationship names aligned with domain methods.
-- Keep filters and collection query validation synchronized, including locale-aware name/slug filters, active-state filters, soft deletes, relationships, multimedia, pagination, sparse fields, and sorting.
+- Expose read models as API Platform resources in `src/ApiResource` (`ContentPage`, `ContentSection`), backed by `ContentResourceProvider` in `src/State`.
+- Keep the `/content/custom-pages` and `/content/custom-page-categories` resources read-only.
+- Expose translated JSON columns as `array<string, string>` locale maps and hydrate them from the domain models' translations in the state provider.
+- Declare supported query parameters as `QueryParameter`s on the resource operations, using API Platform filters (`EqualsFilter`, `BooleanFilter`, ...) with Laravel `constraints`.
+- Reference the domain models' multimedia and category relations with `Misaf\VendraApi\ApiResource\ResourceReference` instead of embedding foreign models.
+- Apply every declared parameter inside the state provider when building the Eloquent query.
 
 ## Verification
 
-- Test route registration, server schema registration, relationship endpoints, and architecture.
+- Test each resource operation, its query parameters, and architecture.
 - Run package Pest tests, PHPStan, Composer validation, and Pint.

--- a/packages/vendra-faq-api/resources/boost/guidelines/core.blade.php
+++ b/packages/vendra-faq-api/resources/boost/guidelines/core.blade.php
@@ -15,14 +15,14 @@ The `misaf/vendra-faq-api` package exposes `misaf/vendra-faq` domain models thro
 - Apply this only to Vendra platform packages listed under `require`; never extend it to `require-dev`, `suggest`, incidental implementation dependencies, or third-party packages. Removing or replacing an exposed dependency is a breaking change; keep `self.version` alignment across the Vendra package graph.
 
 - Keep API code inside `packages/vendra-faq-api` using the `Misaf\VendraFaqApi` namespace.
-- Use this package for API Platform servers, schemas, resources, query validators, API routes, service providers, and API tests.
+- Use this package for API Platform resources (`ApiResource` DTOs), state providers, query parameters, service providers, and API tests.
 - Import domain models from `Misaf\VendraFaq`; do not duplicate persistence or domain behavior in the API module.
 - Keep Filament/admin UI in `misaf/vendra-faq`.
 - Respect domain model tenancy. Tenant awareness is owned by `misaf/vendra-support` and derives from the bound `TenantResolver` (installing `misaf/vendra-tenant` enables it); there is no `tenant_aware` config toggle.
-- Keep production API code tenant-provider agnostic: inherit tenancy through the `Misaf\VendraFaq` models and never reference `Misaf\VendraTenant` in servers, schemas, queries, or routes. Feature tests may use a concrete tenant factory solely to establish tenant context; architecture expectations remain scoped to the production `Misaf\VendraFaqApi` namespace.
-- Register `FaqCategorySchema`, `FaqSchema`, and `MultimediaSchema` in `API Platform resource discovery`. FAQ multimedia relationships and include paths require the multimedia schema on the same API Platform server.
-- Keep schema filters and request validation rules synchronized.
+- Keep production API code tenant-provider agnostic: inherit tenancy through the `Misaf\VendraFaq` models and never reference `Misaf\VendraTenant` in resources, state providers, or query parameters. Feature tests may use a concrete tenant factory solely to establish tenant context; architecture expectations remain scoped to the production `Misaf\VendraFaqApi` namespace.
+- Expose `HelpArticle` and `HelpTopic` resources, and reference FAQ multimedia relations with `Misaf\VendraApi\ApiResource\ResourceReference`.
+- Declare query parameters on the resource operations and apply them in the state provider.
 - Follow Laravel comment style: document with PHPDoc (array shapes, generics, `@see`) and reserve inline comments for genuinely complex logic. Match the surrounding file and do not add comments that restate the code.
-- Add or update Pest tests for routes, server schema registration, filters, includes, pagination, sorting, sparse fieldsets, and relationship endpoints.
+- Add or update Pest tests for each resource operation, query parameters, and pagination.
 - Keep tests purposeful and prevent unnecessary ones: cover behavior, contracts, and edge cases — not framework internals or trivially typed code. Do not duplicate coverage a focused test already proves, and do not add throwaway verification scripts when a test fits.
 - Keep Pest architecture tests in `tests/ArchTest.php`: the `php`, `security`, and `laravel` presets plus a tenant-agnostic expectation, e.g. `arch()->expect('Misaf\VendraFaqApi')->not->toUse('Misaf\VendraTenant')`.

--- a/packages/vendra-faq-api/resources/boost/skills/vendra-faq-api-development/SKILL.md
+++ b/packages/vendra-faq-api/resources/boost/skills/vendra-faq-api-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vendra-faq-api-development
-description: "Create, modify, review, or test the Vendra FAQ API module in packages/vendra-faq-api. Use for ApiResource DTOs, schemas, resources, collection queries, resource queries, API Platform routes, include paths, filters, pagination, sortables, API relationships, API tests, and package service provider wiring."
+description: "Create, modify, review, or test the Vendra FAQ API module in packages/vendra-faq-api. Use for ApiResource DTOs, State providers, query parameters, API Platform operations, filters, pagination, FAQ and multimedia relationships, API tests, and package service provider wiring."
 ---
 
 # Vendra FAQ API
@@ -31,64 +31,56 @@ description: "Create, modify, review, or test the Vendra FAQ API module in packa
 Treat `packages/vendra-faq-api` as the API Platform layer for `misaf/vendra-faq`.
 
 - Use namespace `Misaf\VendraFaqApi`.
-- Keep API servers, schemas, API resources, query validators, routes, service providers, and API tests inside this module.
+- Keep API resource DTOs, state providers, query parameters, service providers, and API tests inside this module.
 - Import domain models from `Misaf\VendraFaq`; do not duplicate domain models or persistence logic in the API module.
-- Keep production API code tenant-provider agnostic: inherit tenancy from the domain models and add no API tenant toggle or `Misaf\VendraTenant` reference in servers, schemas, queries, or routes. Feature tests may use a concrete tenant factory solely to establish tenant context; keep the architecture rule scoped to `Misaf\VendraFaqApi`.
+- Keep production API code tenant-provider agnostic: inherit tenancy from the domain models and add no API tenant toggle or `Misaf\VendraTenant` reference in resources, state providers, or query parameters. Feature tests may use a concrete tenant factory solely to establish tenant context; keep the architecture rule scoped to `Misaf\VendraFaqApi`.
 - Keep Filament/admin UI out of this module.
 - Keep dependencies explicit in `composer.json`; do not add or change package dependencies without approval.
 
 ## API Platform Shape
 
-Follow the current `JsonApi/V1` layout.
+Expose read models as API Platform resources in `src/ApiResource` (`HelpArticle`, `HelpTopic`), backed by state providers in `src/State` (for example `HelpResourceProvider`).
 
-- Register routes in `routes/api.php` with `JsonApiRoute::server('vendra-faq')->prefix('v1')`.
-- Use `JsonApiController` for standard resource endpoints.
-- Keep resource type names kebab-case and stable, for example `faqs`, `faq-categories`.
-- Register `FaqCategorySchema`, `FaqSchema`, and `MultimediaSchema` in `API Platform resource discovery`. The FAQ multimedia relationships and include paths require the multimedia schema on the same server.
-- Keep `authorizable()` behavior intentional; do not silently enable or disable authorization.
-- Use schema classes for fields, relationships, filters, pagination, and sortables.
+- Define each resource as a `final readonly` DTO annotated with `#[ApiResource]`, declaring `Get`/`GetCollection` operations with explicit `uriTemplate` paths and a `provider`.
+- Keep each resource `shortName` and URI path stable and kebab-case, for example `/content/faqs`, `/content/faq-categories`.
+- Reference related resources, including multimedia, with `Misaf\VendraApi\ApiResource\ResourceReference` instead of embedding foreign models.
+- Register the `src/ApiResource` directory into `api-platform.resources` and tag each state provider as `ProviderInterface` in the module service provider.
+- Keep resources read-only unless a mutation is an explicit product decision.
 
-## Schema Standards
+## Resource DTO Standards
 
-Schema classes define the public API contract.
+Resource DTOs define the public API contract.
 
-- Use `ID::make()` and typed field classes instead of raw arrays.
-- Use `ArrayHash` for translated JSON columns such as `name`, `description`, and `slug`.
-- Mark generated, positional, timestamp, media, and relationship fields read-only where clients should not mutate them.
-- Keep include paths explicit and minimal.
-- Use `PagePagination::make()` and preserve default pagination unless product requirements change.
-- Expose sortable fields with `->sortable()` and add custom sortables in `sortables()`.
-- Keep relationship names aligned with the domain model methods.
+- Mark the identifier property with `#[ApiProperty(identifier: true)]` and give every property an explicit type.
+- Expose translated columns as `array<string, string>` locale maps such as `title` and `description`.
+- Keep raw foreign keys and internal columns off the DTO; expose only intentionally public fields.
+- Do the Eloquent querying, hydration, filtering, and pagination in the state provider, not the DTO.
 
 ## Filter And Query Standards
 
-Keep schema filters and request validation in sync.
+Declare supported query parameters on the resource operation.
 
-- Add every schema filter to the matching `ResourceQuery` or `CollectionQuery` validation rules.
-- Declare supported query parameters with API Platform filters and Laravel validation constraints.
-- For translated attribute filters, use the active locale path such as `name->{$locale}` and `slug->{$locale}`.
-- Use `like` filters with deserialization only for intentional partial text search.
-- Use `WhereIdIn` and `WhereIdNotIn` for id inclusion and exclusion.
-- Use `Has`, `WhereHas`, and `WhereDoesntHave` for relationship filters.
-- Keep soft-delete filter rules aligned with actual schema behavior before exposing `with-trashed` or `only-trashed`.
+- Add each filter as a `QueryParameter` with an API Platform filter (`EqualsFilter`, `BooleanFilter`, ...) and Laravel `constraints`.
+- Set each parameter's `property` to the model column the state provider filters on.
+- Apply the declared parameters inside the state provider when building the Eloquent query.
+- For translated column filters, filter on the active-locale JSON path.
 
 ## Service Provider And Routes
 
 Keep package bootstrapping minimal and predictable.
 
-- Use the module `ServiceProvider` for package configuration and route loading.
-- Load only this module's API routes from the API module.
-- Keep routes localization-package agnostic and use only Laravel's `api` middleware. Locale-aware filters read Laravel's current locale, which the host application may resolve by any mechanism.
-- Do not use host-app route files for module endpoints unless integrating the package at application level.
+- Use the module `ServiceProvider` to register `src/ApiResource` into `api-platform.resources` and tag the state providers; API Platform generates routes from the resource operations.
+- Do not hand-register route files for resource endpoints.
+- Keep routes localization-package agnostic; locale-aware providers read Laravel's current locale, which the host application may resolve by any mechanism.
 
 ## Testing And Verification
 
 Use Pest tests to protect API contracts.
 
 - Keep tests purposeful and prevent unnecessary ones: cover behavior, contracts, and edge cases — not framework internals or trivially typed code. Do not duplicate coverage a focused test already proves, and do not add throwaway verification scripts (or `tinker`) when a test fits.
-- Add route tests for every new resource endpoint and relationship endpoint.
-- Add server tests when schemas, resource names, or `Server` behavior changes.
-- Add request validation tests when filters, includes, sparse fieldsets, sorting, pagination, or relationship filters change.
+- Add tests for every new resource operation and its query parameters.
+- Add tests when resource shape, `shortName`, or URI paths change.
+- Add tests when query parameters, filters, or pagination change.
 - Keep Pest architecture tests in `tests/ArchTest.php`: the `php`, `security`, and `laravel` presets, plus an expectation that the module stays tenant-agnostic, e.g. `arch()->expect('Misaf\VendraFaqApi')->not->toUse('Misaf\VendraTenant')`. The API module may depend on `Misaf\VendraFaq`, but not on any concrete tenant provider.
 - Run module checks from the package when possible: `composer --working-dir=packages/vendra-faq-api test` and `composer --working-dir=packages/vendra-faq-api analyse`.
 - If PHP files changed, run Pint for the touched code: `vendor/bin/pint --dirty --format agent` from the host app, or the module formatter if working only inside the package.

--- a/packages/vendra-multimedia-api/resources/boost/guidelines/core.blade.php
+++ b/packages/vendra-multimedia-api/resources/boost/guidelines/core.blade.php
@@ -15,13 +15,13 @@ The `misaf/vendra-multimedia-api` package exposes `misaf/vendra-multimedia` doma
 - Apply this only to Vendra platform packages listed under `require`; never extend it to `require-dev`, `suggest`, incidental implementation dependencies, or third-party packages. Removing or replacing an exposed dependency is a breaking change; keep `self.version` alignment across the Vendra package graph.
 
 - Keep API code inside `packages/vendra-multimedia-api` using the `Misaf\VendraMultimediaApi` namespace.
-- Use this package for API Platform servers, schemas, resources, query validators, API routes, service providers, and API tests.
+- Use this package for API Platform resources (`ApiResource` DTOs), state providers, query parameters, service providers, and API tests.
 - Import domain models from `Misaf\VendraMultimedia`; do not duplicate persistence or domain behavior in the API module.
 - Keep Filament/admin UI in `misaf/vendra-multimedia`.
 - Respect domain model tenancy. Tenant awareness is owned by `misaf/vendra-support` and derives from the bound `TenantResolver` (installing `misaf/vendra-tenant` enables it); there is no `tenant_aware` config toggle.
-- Keep production API code tenant-provider agnostic: inherit tenancy through the `Misaf\VendraMultimedia` models and never reference `Misaf\VendraTenant` in servers, schemas, queries, or routes. Feature tests may use a concrete tenant factory solely to establish tenant context; architecture expectations remain scoped to the production `Misaf\VendraMultimediaApi` namespace.
-- Keep schema filters and request validation rules synchronized.
+- Keep production API code tenant-provider agnostic: inherit tenancy through the `Misaf\VendraMultimedia` models and never reference `Misaf\VendraTenant` in resources, state providers, or query parameters. Feature tests may use a concrete tenant factory solely to establish tenant context; architecture expectations remain scoped to the production `Misaf\VendraMultimediaApi` namespace.
+- Declare query parameters on the resource operations and apply them in the state provider.
 - Follow Laravel comment style: document with PHPDoc (array shapes, generics, `@see`) and reserve inline comments for genuinely complex logic. Match the surrounding file and do not add comments that restate the code.
-- Add or update Pest tests for routes, server schema registration, filters, includes, pagination, sorting, sparse fieldsets, and relationship endpoints.
+- Add or update Pest tests for each resource operation, query parameters, and pagination.
 - Keep tests purposeful and prevent unnecessary ones: cover behavior, contracts, and edge cases — not framework internals or trivially typed code. Do not duplicate coverage a focused test already proves, and do not add throwaway verification scripts when a test fits.
 - Keep Pest architecture tests in `tests/ArchTest.php`: the `php`, `security`, and `laravel` presets plus a tenant-agnostic expectation, e.g. `arch()->expect('Misaf\VendraMultimediaApi')->not->toUse('Misaf\VendraTenant')`.

--- a/packages/vendra-multimedia-api/resources/boost/skills/vendra-multimedia-api-development/SKILL.md
+++ b/packages/vendra-multimedia-api/resources/boost/skills/vendra-multimedia-api-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vendra-multimedia-api-development
-description: "Create, modify, review, or test the Vendra Multimedia API module in packages/vendra-multimedia-api. Use for ApiResource DTOs, schemas, resources, collection queries, resource queries, API Platform routes, include paths, filters, pagination, sortables, API relationships, API tests, and package service provider wiring."
+description: "Create, modify, review, or test the Vendra Multimedia API module in packages/vendra-multimedia-api. Use for ApiResource DTOs, State providers, query parameters, API Platform operations, filters, pagination, API relationships, API tests, and package service provider wiring."
 ---
 
 # Vendra Multimedia API
@@ -31,64 +31,56 @@ description: "Create, modify, review, or test the Vendra Multimedia API module i
 Treat `packages/vendra-multimedia-api` as the API Platform layer for `misaf/vendra-multimedia`.
 
 - Use namespace `Misaf\VendraMultimediaApi`.
-- Keep API servers, schemas, API resources, query validators, routes, service providers, and API tests inside this module.
+- Keep API resource DTOs, state providers, query parameters, service providers, and API tests inside this module.
 - Import domain models from `Misaf\VendraMultimedia`; do not duplicate domain models or persistence logic in the API module.
-- Keep production API code tenant-provider agnostic: inherit tenancy from the domain models and add no API tenant toggle or `Misaf\VendraTenant` reference in servers, schemas, queries, or routes. Feature tests may use a concrete tenant factory solely to establish tenant context; keep the architecture rule scoped to `Misaf\VendraMultimediaApi`.
+- Keep production API code tenant-provider agnostic: inherit tenancy from the domain models and add no API tenant toggle or `Misaf\VendraTenant` reference in resources, state providers, or query parameters. Feature tests may use a concrete tenant factory solely to establish tenant context; keep the architecture rule scoped to `Misaf\VendraMultimediaApi`.
 - Keep Filament/admin UI out of this module.
 - Keep dependencies explicit in `composer.json`; do not add or change package dependencies without approval.
 
 ## API Platform Shape
 
-Follow the current `JsonApi/V1` layout.
+Expose read models as API Platform resources in `src/ApiResource` (`Asset`), backed by state providers in `src/State` (for example `AssetProvider`).
 
-- Register routes in `routes/api.php` with `JsonApiRoute::server('vendra-multimedia')->prefix('v1')`.
-- Use `JsonApiController` for standard resource endpoints.
-- Keep resource type names kebab-case and stable, for example `multimedia`.
-- Register schemas in `API Platform resource discovery`.
-- Keep `authorizable()` behavior intentional; do not silently enable or disable authorization.
-- Use schema classes for fields, relationships, filters, pagination, and sortables.
+- Define each resource as a `final readonly` DTO annotated with `#[ApiResource]`, declaring `Get`/`GetCollection` operations with explicit `uriTemplate` paths and a `provider`.
+- Keep each resource `shortName` and URI path stable and kebab-case, for example `/content/multimedia`.
+- Reference related resources with `Misaf\VendraApi\ApiResource\ResourceReference` instead of embedding foreign models.
+- Register the `src/ApiResource` directory into `api-platform.resources` and tag each state provider as `ProviderInterface` in the module service provider.
+- Keep resources read-only unless a mutation is an explicit product decision.
 
-## Schema Standards
+## Resource DTO Standards
 
-Schema classes define the public API contract.
+Resource DTOs define the public API contract.
 
-- Use `ID::make()` and typed field classes instead of raw arrays.
-- Use `ArrayHash` for translated JSON columns such as `name`, `description`, and `slug`.
-- Mark generated, positional, timestamp, media, and relationship fields read-only where clients should not mutate them.
-- Keep include paths explicit and minimal.
-- Use `PagePagination::make()` and preserve default pagination unless product requirements change.
-- Expose sortable fields with `->sortable()` and add custom sortables in `sortables()`.
-- Keep relationship names aligned with the domain model methods.
+- Mark the identifier property with `#[ApiProperty(identifier: true)]` and give every property an explicit type.
+- Expose translated columns as `array<string, string>` locale maps such as `title` and `description`.
+- Keep raw foreign keys and internal columns off the DTO; expose only intentionally public fields.
+- Do the Eloquent querying, hydration, filtering, and pagination in the state provider, not the DTO.
 
 ## Filter And Query Standards
 
-Keep schema filters and request validation in sync.
+Declare supported query parameters on the resource operation.
 
-- Add every schema filter to the matching `ResourceQuery` or `CollectionQuery` validation rules.
-- Declare supported query parameters with API Platform filters and Laravel validation constraints.
-- For translated attribute filters, use the active locale path such as `name->{$locale}` and `slug->{$locale}`.
-- Use `like` filters with deserialization only for intentional partial text search.
-- Use `WhereIdIn` and `WhereIdNotIn` for id inclusion and exclusion.
-- Use `Has`, `WhereHas`, and `WhereDoesntHave` for relationship filters.
-- Keep soft-delete filter rules aligned with actual schema behavior before exposing `with-trashed` or `only-trashed`.
+- Add each filter as a `QueryParameter` with an API Platform filter (`EqualsFilter`, `BooleanFilter`, ...) and Laravel `constraints`.
+- Set each parameter's `property` to the model column the state provider filters on.
+- Apply the declared parameters inside the state provider when building the Eloquent query.
+- For translated column filters, filter on the active-locale JSON path.
 
 ## Service Provider And Routes
 
 Keep package bootstrapping minimal and predictable.
 
-- Use the module `ServiceProvider` for package configuration and route loading.
-- Load only this module's API routes from the API module.
-- Keep routes localization-package agnostic and use only Laravel's `api` middleware.
-- Do not use host-app route files for module endpoints unless integrating the package at application level.
+- Use the module `ServiceProvider` to register `src/ApiResource` into `api-platform.resources` and tag the state providers; API Platform generates routes from the resource operations.
+- Do not hand-register route files for resource endpoints.
+- Keep routes localization-package agnostic; locale-aware providers read Laravel's current locale, which the host application may resolve by any mechanism.
 
 ## Testing And Verification
 
 Use Pest tests to protect API contracts.
 
 - Keep tests purposeful and prevent unnecessary ones: cover behavior, contracts, and edge cases — not framework internals or trivially typed code. Do not duplicate coverage a focused test already proves, and do not add throwaway verification scripts (or `tinker`) when a test fits.
-- Add route tests for every new resource endpoint and relationship endpoint.
-- Add server tests when schemas, resource names, or `Server` behavior changes.
-- Add request validation tests when filters, includes, sparse fieldsets, sorting, pagination, or relationship filters change.
+- Add tests for every new resource operation and its query parameters.
+- Add tests when resource shape, `shortName`, or URI paths change.
+- Add tests when query parameters, filters, or pagination change.
 - Keep Pest architecture tests in `tests/ArchTest.php`: the `php`, `security`, and `laravel` presets, plus an expectation that the module stays tenant-agnostic, e.g. `arch()->expect('Misaf\VendraMultimediaApi')->not->toUse('Misaf\VendraTenant')`. The API module may depend on `Misaf\VendraMultimedia`, but not on any concrete tenant provider.
 - Run module checks from the package when possible: `composer --working-dir=packages/vendra-multimedia-api test` and `composer --working-dir=packages/vendra-multimedia-api analyse`.
 - If PHP files changed, run Pint for the touched code: `vendor/bin/pint --dirty --format agent` from the host app, or the module formatter if working only inside the package.

--- a/packages/vendra-product-api/resources/boost/guidelines/core.blade.php
+++ b/packages/vendra-product-api/resources/boost/guidelines/core.blade.php
@@ -15,13 +15,13 @@ The `misaf/vendra-product-api` package exposes `misaf/vendra-product` domain mod
 - Apply this only to Vendra platform packages listed under `require`; never extend it to `require-dev`, `suggest`, incidental implementation dependencies, or third-party packages. Removing or replacing an exposed dependency is a breaking change; keep `self.version` alignment across the Vendra package graph.
 
 - Keep API code inside `packages/vendra-product-api` using the `Misaf\VendraProductApi` namespace.
-- Use this package for API Platform servers, schemas, resources, query validators, API routes, service providers, and API tests.
+- Use this package for API Platform resources (`ApiResource` DTOs), state providers, query parameters, service providers, and API tests.
 - Import domain models from `Misaf\VendraProduct`; do not duplicate persistence or domain behavior in the API module.
 - Keep Filament/admin UI in `misaf/vendra-product`.
 - Respect domain model tenancy. Tenant awareness is owned by `misaf/vendra-support` and derives from the bound `TenantResolver` (installing `misaf/vendra-tenant` enables it); there is no `tenant_aware` config toggle.
-- Keep production API code tenant-provider agnostic: inherit tenancy through the `Misaf\VendraProduct` models and never reference `Misaf\VendraTenant` in servers, schemas, queries, or routes. Feature tests may use a concrete tenant factory solely to establish tenant context; architecture expectations remain scoped to the production `Misaf\VendraProductApi` namespace.
-- Keep schema filters and request validation rules synchronized.
+- Keep production API code tenant-provider agnostic: inherit tenancy through the `Misaf\VendraProduct` models and never reference `Misaf\VendraTenant` in resources, state providers, or query parameters. Feature tests may use a concrete tenant factory solely to establish tenant context; architecture expectations remain scoped to the production `Misaf\VendraProductApi` namespace.
+- Declare query parameters on the resource operations and apply them in the state provider.
 - Follow Laravel comment style: document with PHPDoc (array shapes, generics, `@see`) and reserve inline comments for genuinely complex logic. Match the surrounding file and do not add comments that restate the code.
-- Add or update Pest tests for routes, server schema registration, filters, includes, pagination, sorting, sparse fieldsets, and relationship endpoints.
+- Add or update Pest tests for each resource operation, query parameters, and pagination.
 - Keep tests purposeful and prevent unnecessary ones: cover behavior, contracts, and edge cases — not framework internals or trivially typed code. Do not duplicate coverage a focused test already proves, and do not add throwaway verification scripts when a test fits.
 - Keep Pest architecture tests in `tests/ArchTest.php`: the `php`, `security`, and `laravel` presets plus a tenant-agnostic expectation, e.g. `arch()->expect('Misaf\VendraProductApi')->not->toUse('Misaf\VendraTenant')`.

--- a/packages/vendra-product-api/resources/boost/skills/vendra-product-api-development/SKILL.md
+++ b/packages/vendra-product-api/resources/boost/skills/vendra-product-api-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vendra-product-api-development
-description: "Create, modify, review, or test the Vendra Product API module in packages/vendra-product-api. Use for ApiResource DTOs, schemas, resources, collection queries, resource queries, API Platform routes, include paths, filters, pagination, sortables, API relationships, API tests, and package service provider wiring."
+description: "Create, modify, review, or test the Vendra Product API module in packages/vendra-product-api. Use for ApiResource DTOs, State providers, query parameters, API Platform operations, filters, pagination, catalog relationships, API tests, and package service provider wiring."
 ---
 
 # Vendra Product API
@@ -31,64 +31,56 @@ description: "Create, modify, review, or test the Vendra Product API module in p
 Treat `packages/vendra-product-api` as the API Platform layer for `misaf/vendra-product`.
 
 - Use namespace `Misaf\VendraProductApi`.
-- Keep API servers, schemas, API resources, query validators, routes, service providers, and API tests inside this module.
+- Keep API resource DTOs, state providers, query parameters, service providers, and API tests inside this module.
 - Import domain models from `Misaf\VendraProduct`; do not duplicate domain models or persistence logic in the API module.
-- Keep production API code tenant-provider agnostic: inherit tenancy from the domain models and add no API tenant toggle or `Misaf\VendraTenant` reference in servers, schemas, queries, or routes. Feature tests may use a concrete tenant factory solely to establish tenant context; keep the architecture rule scoped to `Misaf\VendraProductApi`.
+- Keep production API code tenant-provider agnostic: inherit tenancy from the domain models and add no API tenant toggle or `Misaf\VendraTenant` reference in resources, state providers, or query parameters. Feature tests may use a concrete tenant factory solely to establish tenant context; keep the architecture rule scoped to `Misaf\VendraProductApi`.
 - Keep Filament/admin UI out of this module.
 - Keep dependencies explicit in `composer.json`; do not add or change package dependencies without approval.
 
 ## API Platform Shape
 
-Follow the current `JsonApi/V1` layout.
+Expose read models as API Platform resources in `src/ApiResource`, backed by state providers in `src/State` (for example `ProductResourceProvider`).
 
-- Register routes in `routes/api.php` with `JsonApiRoute::server('vendra-product')->prefix('v1')`.
-- Use `JsonApiController` for standard resource endpoints.
-- Keep resource type names kebab-case and stable, for example `products`, `product-categories`, `product-prices`.
-- Register schemas in `API Platform resource discovery`.
-- Keep `authorizable()` behavior intentional; do not silently enable or disable authorization.
-- Use schema classes for fields, relationships, filters, pagination, and sortables.
+- Define each resource as a `final readonly` DTO annotated with `#[ApiResource]`, declaring `Get`/`GetCollection` operations with explicit `uriTemplate` paths and a `provider`.
+- Keep each resource `shortName` and URI path stable and kebab-case, for example `/catalog/products`, `/catalog/product-categories`, `/catalog/product-prices`.
+- Reference related resources with `Misaf\VendraApi\ApiResource\ResourceReference` instead of embedding foreign models.
+- Register the `src/ApiResource` directory into `api-platform.resources` and tag each state provider as `ProviderInterface` in the module service provider.
+- Keep resources read-only unless a mutation is an explicit product decision.
 
-## Schema Standards
+## Resource DTO Standards
 
-Schema classes define the public API contract.
+Resource DTOs define the public API contract.
 
-- Use `ID::make()` and typed field classes instead of raw arrays.
-- Use `ArrayHash` for translated JSON columns such as `name`, `description`, and `slug`.
-- Mark generated, positional, timestamp, media, and relationship fields read-only where clients should not mutate them.
-- Keep include paths explicit and minimal.
-- Use `PagePagination::make()` and preserve default pagination unless product requirements change.
-- Expose sortable fields with `->sortable()` and add custom sortables in `sortables()`.
-- Keep relationship names aligned with the domain model methods.
+- Mark the identifier property with `#[ApiProperty(identifier: true)]` and give every property an explicit type.
+- Expose translated columns as `array<string, string>` locale maps such as `title` and `description`.
+- Keep raw foreign keys and internal columns off the DTO; expose only intentionally public fields.
+- Do the Eloquent querying, hydration, filtering, and pagination in the state provider, not the DTO.
 
 ## Filter And Query Standards
 
-Keep schema filters and request validation in sync.
+Declare supported query parameters on the resource operation.
 
-- Add every schema filter to the matching `ResourceQuery` or `CollectionQuery` validation rules.
-- Declare supported query parameters with API Platform filters and Laravel validation constraints.
-- For translated attribute filters, use the active locale path such as `name->{$locale}` and `slug->{$locale}`.
-- Use `like` filters with deserialization only for intentional partial text search.
-- Use `WhereIdIn` and `WhereIdNotIn` for id inclusion and exclusion.
-- Use `Has`, `WhereHas`, and `WhereDoesntHave` for relationship filters.
-- Keep soft-delete filter rules aligned with actual schema behavior before exposing `with-trashed` or `only-trashed`.
+- Add each filter as a `QueryParameter` with an API Platform filter (`EqualsFilter`, `BooleanFilter`, ...) and Laravel `constraints`.
+- Set each parameter's `property` to the model column the state provider filters on.
+- Apply the declared parameters inside the state provider when building the Eloquent query.
+- For translated column filters, filter on the active-locale JSON path.
 
 ## Service Provider And Routes
 
 Keep package bootstrapping minimal and predictable.
 
-- Use the module `ServiceProvider` for package configuration and route loading.
-- Load only this module's API routes from the API module.
-- Keep routes localization-package agnostic and use only Laravel's `api` middleware. Locale-aware filters read Laravel's current locale, which the host application may resolve by any mechanism.
-- Do not use host-app route files for module endpoints unless integrating the package at application level.
+- Use the module `ServiceProvider` to register `src/ApiResource` into `api-platform.resources` and tag the state providers; API Platform generates routes from the resource operations.
+- Do not hand-register route files for resource endpoints.
+- Keep routes localization-package agnostic; locale-aware providers read Laravel's current locale, which the host application may resolve by any mechanism.
 
 ## Testing And Verification
 
 Use Pest tests to protect API contracts.
 
 - Keep tests purposeful and prevent unnecessary ones: cover behavior, contracts, and edge cases — not framework internals or trivially typed code. Do not duplicate coverage a focused test already proves, and do not add throwaway verification scripts (or `tinker`) when a test fits.
-- Add route tests for every new resource endpoint and relationship endpoint.
-- Add server tests when schemas, resource names, or `Server` behavior changes.
-- Add request validation tests when filters, includes, sparse fieldsets, sorting, pagination, or relationship filters change.
+- Add tests for every new resource operation and its query parameters.
+- Add tests when resource shape, `shortName`, or URI paths change.
+- Add tests when query parameters, filters, or pagination change.
 - Keep Pest architecture tests in `tests/ArchTest.php`: the `php`, `security`, and `laravel` presets, plus an expectation that the module stays tenant-agnostic, e.g. `arch()->expect('Misaf\VendraProductApi')->not->toUse('Misaf\VendraTenant')`. The API module may depend on `Misaf\VendraProduct`, but not on any concrete tenant provider.
 - Run module checks from the package when possible: `composer --working-dir=packages/vendra-product-api test` and `composer --working-dir=packages/vendra-product-api analyse`.
 - If PHP files changed, run Pint for the touched code: `vendor/bin/pint --dirty --format agent` from the host app, or the module formatter if working only inside the package.


### PR DESCRIPTION
Closes #18

## What drifted

Issue #18 asks whether recent changes are missing from the documentation. The recent commits migrated every `*-api` package **from Laravel JSON:API to API Platform** (`app: switch from Laravel JSON:API to API Platform` and the per-package migration commits). The package `README`s were updated, but the **Laravel Boost skills and guidelines** — the docs that steer contributors/agents working in these packages — still described the removed JSON:API layer.

Stale references that no longer exist in the code:

- `JsonApiRoute::server(...)`, `JsonApiController`, `routes/api.php` route registration
- `JsonApiRule::boolean()->asString()`
- Schema classes and `ID::make()` / `ArrayHash` / `PagePagination` / `sortables()`
- `ResourceQuery` / `CollectionQuery` validators, `WhereIdIn`, `Has`/`WhereHas`
- `jsonapi.servers.*` server registration, `JsonApi/Filters`, `JsonApi/Sorting`
- `AttributeSchema` / `AttributeValueSchema`, `owner_label`, "sparse fieldsets", "server schema registration"

## What changed

Rewrote the affected Boost **skills** (`SKILL.md`) and **guidelines** (`core.blade.php`) to match the actual architecture now in `src/`:

- `#[ApiResource]` DTOs in `src/ApiResource` backed by State providers in `src/State`
- Operations with explicit `uriTemplate` paths; routing generated by API Platform (no hand-registered route files)
- `QueryParameter` + API Platform filters (`EqualsFilter`, `BooleanFilter`) with Laravel `constraints`, applied in the state provider
- `ResourceReference` for related resources; translated columns as `array<string,string>` locale maps
- Cart API's authenticated (`auth:sanctum` + `ShoppingCartPolicy`) read-only operations and private owner columns

Packages touched: `vendra-api`, `vendra-product-api`, `vendra-faq-api`, `vendra-multimedia-api`, `vendra-blog-api`, `vendra-cart-api`, `vendra-custom-page-api`, `vendra-attribute-api`, `vendra-affiliate-api`.

Documentation-only change; no source or tests affected. Descriptions were verified against the current `src/ApiResource` and `src/State` classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)